### PR TITLE
Removed reference to an unfinished collector for LANDesk.

### DIFF
--- a/Wintap.csproj
+++ b/Wintap.csproj
@@ -359,7 +359,6 @@
     <Compile Include="collect\misc\WebActivityCollector.cs" />
     <Compile Include="collect\etw\MicrosoftWindowsBitLockerAPICollector.cs" />
     <Compile Include="collect\etw\MicrosoftWindowsGroupPolicyCollector.cs" />
-    <Compile Include="collect\log\LANDeskCollector.cs" />
     <Compile Include="collect\sens\SensCollector.cs" />
     <Compile Include="collect\shared\BaseCollector.cs" />
     <Compile Include="collect\shared\EtwCollector.cs" />


### PR DESCRIPTION
This class file was not included in the initial commit, however the reference to was still there.  This hotfix cleans up the orphaned reference.